### PR TITLE
Implement `FromLatLon` (a.k.a `lat_long2n_E`)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/ezzatron/nvector-go
 
 go 1.22.2
 
-require gonum.org/v1/gonum v0.15.0
+require (
+	github.com/gorilla/websocket v1.5.1
+	gonum.org/v1/gonum v0.15.0
+)
+
+require golang.org/x/net v0.17.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/ezzatron/nvector-go
 
 go 1.22.2
+
+require gonum.org/v1/gonum v0.15.0

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.2
 require (
 	github.com/gorilla/websocket v1.5.1
 	gonum.org/v1/gonum v0.15.0
+	pgregory.net/rapid v1.1.0
 )
 
 require golang.org/x/net v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa h1:FRnLl4eNAQl8hwxVVC17teOw8kdjVDVAiFMtgUdTSRQ=
+golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa/go.mod h1:zk2irFbV9DP96SEBUUAy67IdHUaZuSnrz1n472HUCLE=
+gonum.org/v1/gonum v0.15.0 h1:2lYxjRbTYyxkJxlhC+LvJIx3SsANPdRybu1tGj9/OrQ=
+gonum.org/v1/gonum v0.15.0/go.mod h1:xzZVBJBtS+Mz4q0Yl2LJTk+OxOg4jiXZ7qBoM0uISGo=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
+github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
+github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa h1:FRnLl4eNAQl8hwxVVC17teOw8kdjVDVAiFMtgUdTSRQ=
 golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa/go.mod h1:zk2irFbV9DP96SEBUUAy67IdHUaZuSnrz1n472HUCLE=
+golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
+golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
 gonum.org/v1/gonum v0.15.0 h1:2lYxjRbTYyxkJxlhC+LvJIx3SsANPdRybu1tGj9/OrQ=
 gonum.org/v1/gonum v0.15.0/go.mod h1:xzZVBJBtS+Mz4q0Yl2LJTk+OxOg4jiXZ7qBoM0uISGo=

--- a/go.sum
+++ b/go.sum
@@ -6,3 +6,5 @@ golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
 golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
 gonum.org/v1/gonum v0.15.0 h1:2lYxjRbTYyxkJxlhC+LvJIx3SsANPdRybu1tGj9/OrQ=
 gonum.org/v1/gonum v0.15.0/go.mod h1:xzZVBJBtS+Mz4q0Yl2LJTk+OxOg4jiXZ7qBoM0uISGo=
+pgregory.net/rapid v1.1.0 h1:CMa0sjHSru3puNx+J0MIAuiiEV4N0qj8/cMWGBBCsjw=
+pgregory.net/rapid v1.1.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -1,0 +1,28 @@
+package options
+
+import "gonum.org/v1/gonum/mat"
+
+// Options contains optional parameters for n-vector calculations.
+type Options struct {
+	// CoordFrame defines the axes of the coordinate frame E.
+	CoordFrame mat.Matrix
+}
+
+// Option is a functional option for n-vector calculations.
+type Option func(*Options)
+
+// New creates a new Options with the given options.
+func New(opts []Option) *Options {
+	o := &Options{
+		CoordFrame: mat.NewDense(3, 3, []float64{
+			0, 0, 1,
+			0, 1, 0,
+			-1, 0, 0,
+		}),
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return o
+}

--- a/internal/rapidgen/coords.go
+++ b/internal/rapidgen/coords.go
@@ -1,0 +1,13 @@
+package rapidgen
+
+import "pgregory.net/rapid"
+
+// Latitude creates a rapid generator for latitudes.
+func Latitude() *rapid.Generator[float64] {
+	return rapid.Float64Range(-90, 90)
+}
+
+// Longitude creates a rapid generator for longitudes.
+func Longitude() *rapid.Generator[float64] {
+	return rapid.Float64Range(-180, 180)
+}

--- a/internal/rapidgen/options.go
+++ b/internal/rapidgen/options.go
@@ -1,0 +1,20 @@
+package rapidgen
+
+import (
+	"github.com/ezzatron/nvector-go"
+	"github.com/ezzatron/nvector-go/internal/options"
+	"pgregory.net/rapid"
+)
+
+// Options creates a rapid generator for n-vector options.
+func Options() *rapid.Generator[[]options.Option] {
+	return rapid.Custom(func(t *rapid.T) []options.Option {
+		return rapid.SliceOfN(
+			rapid.Just(
+				nvector.WithCoordFrame(RotationMatrix().Draw(t, "coordFrame")),
+			),
+			0,
+			1,
+		).Draw(t, "opts")
+	})
+}

--- a/internal/rapidgen/rotation.go
+++ b/internal/rapidgen/rotation.go
@@ -1,0 +1,57 @@
+package rapidgen
+
+import (
+	"math"
+
+	"gonum.org/v1/gonum/mat"
+	"gonum.org/v1/gonum/num/quat"
+	"pgregory.net/rapid"
+)
+
+// Quaternion creates a rapid generator for quaternions.
+func Quaternion() *rapid.Generator[quat.Number] {
+	return rapid.Custom(func(t *rapid.T) quat.Number {
+		// based on https://github.com/mrdoob/three.js/blob/a2e9ee8204b67f9dca79f48cf620a34a05aa8126/src/math/Quaternion.js#L592
+		// Ken Shoemake
+		// Uniform random rotations
+		// D. Kirk, editor, Graphics Gems III, pages 124-132. Academic Press, New York, 1992.
+		theta1 := rapid.Float64Range(0, math.Pi*2).Draw(t, "theta1")
+		theta2 := rapid.Float64Range(0, math.Pi*2).Draw(t, "theta2")
+		x0 := rapid.Float64Range(0, 1).Draw(t, "x0")
+
+		r1 := math.Sqrt(1 - x0)
+		r2 := math.Sqrt(x0)
+
+		x := r1 * math.Sin(theta1)
+		y := r1 * math.Cos(theta1)
+		z := r2 * math.Sin(theta2)
+		w := r2 * math.Cos(theta2)
+
+		return quat.Number{Real: w, Imag: x, Jmag: y, Kmag: z}
+	})
+}
+
+// RotationMatrix creates a rapid generator for rotation matrices.
+func RotationMatrix() *rapid.Generator[mat.Matrix] {
+	return rapid.Custom(func(t *rapid.T) mat.Matrix {
+		// based on https://github.com/rawify/Quaternion.js/blob/c3834673b502e64e1866dbbf13568c0be93e52cc/q.js#L791
+		q := Quaternion().Draw(t, "quaternion")
+		w, x, y, z := q.Real, q.Imag, q.Jmag, q.Kmag
+
+		wx := w * x
+		wy := w * y
+		wz := w * z
+		xx := x * x
+		xy := x * y
+		xz := x * z
+		yy := y * y
+		yz := y * z
+		zz := z * z
+
+		return mat.NewDense(3, 3, []float64{
+			1 - 2*(yy+zz), 2 * (xy - wz), 2 * (xz + wy),
+			2 * (xy + wz), 1 - 2*(xx+zz), 2 * (yz - wx),
+			2 * (xz - wy), 2 * (yz + wx), 1 - 2*(xx+yy),
+		})
+	})
+}

--- a/internal/testapi/client.go
+++ b/internal/testapi/client.go
@@ -1,0 +1,64 @@
+package testapi
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gorilla/websocket"
+)
+
+// Client is a websocket client for calling the n-vector test API.
+type Client struct {
+	conn *websocket.Conn
+}
+
+// NewClient creates a new websocket client for calling the n-vector test API.
+func NewClient() (*Client, error) {
+	c, _, err := websocket.DefaultDialer.Dial("ws://localhost:17357/", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{c}, nil
+}
+
+// Close closes the websocket connection.
+func (c *Client) Close() error {
+	err := c.conn.WriteMessage(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+	)
+
+	return errors.Join(err, c.conn.Close())
+}
+
+func call[J, G any](
+	_ context.Context,
+	client *Client,
+	unmarshal func(J) G,
+	fn string,
+	args map[string]any,
+) (result G, _ error) {
+	err := client.conn.WriteJSON(map[string]any{
+		"id":   1,
+		"fn":   fn,
+		"args": args,
+	})
+	if err != nil {
+		return result, err
+	}
+
+	var res struct {
+		Error  string `json:"error"`
+		Result J      `json:"result"`
+	}
+	err = client.conn.ReadJSON(&res)
+	if err != nil {
+		return result, err
+	}
+	if res.Error != "" {
+		return result, errors.New(res.Error)
+	}
+
+	return unmarshal(res.Result), nil
+}

--- a/internal/testapi/latlon.go
+++ b/internal/testapi/latlon.go
@@ -1,0 +1,23 @@
+package testapi
+
+import (
+	"context"
+
+	"github.com/ezzatron/nvector-go/internal/options"
+	"gonum.org/v1/gonum/mat"
+)
+
+// FromLatLon converts a geodetic latitude and longitude to an n-vector.
+func (c *Client) FromLatLon(
+	ctx context.Context,
+	lat, lon float64,
+	opts ...options.Option,
+) (mat.Vector, error) {
+	o := options.New(opts)
+
+	return call(ctx, c, unmarshalVector, "lat_lon2n_E", map[string]any{
+		"latitude":  lat,
+		"longitude": lon,
+		"R_Ee":      marshalMatrix(o.CoordFrame),
+	})
+}

--- a/internal/testapi/marshal.go
+++ b/internal/testapi/marshal.go
@@ -1,0 +1,22 @@
+package testapi
+
+import "gonum.org/v1/gonum/mat"
+
+func marshalMatrix(m mat.Matrix) [][]float64 {
+	r, c := m.Dims()
+	data := make([][]float64, r)
+
+	for i := 0; i < r; i++ {
+		data[i] = make([]float64, c)
+
+		for j := 0; j < c; j++ {
+			data[i][j] = m.At(i, j)
+		}
+	}
+
+	return data
+}
+
+func unmarshalVector(data [][]float64) *mat.VecDense {
+	return mat.NewVecDense(3, []float64{data[0][0], data[1][0], data[2][0]})
+}

--- a/latlon.go
+++ b/latlon.go
@@ -1,0 +1,31 @@
+package nvector
+
+import (
+	"math"
+
+	"github.com/ezzatron/nvector-go/internal/options"
+	"gonum.org/v1/gonum/mat"
+)
+
+// FromLatLon converts a geodetic latitude and longitude to an n-vector.
+//
+// lat and lon are given in radians.
+//
+// See:
+// https://github.com/FFI-no/n-vector/blob/82d749a67cc9f332f48c51aa969cdc277b4199f2/nvector/lat_long2n_E.m
+func FromLatLon(lat, lon float64, opts ...Option) mat.Vector {
+	o := options.New(opts)
+
+	// Equation (3) from Gade (2010):
+	cosLat := math.Cos(lat)
+
+	// CoordFrame selects correct E-axes
+	nv := &mat.VecDense{}
+	nv.MulVec(o.CoordFrame.T(), mat.NewVecDense(3, []float64{
+		math.Sin(lat),
+		math.Sin(lon) * cosLat,
+		-math.Cos(lon) * cosLat,
+	}))
+
+	return nv
+}

--- a/latlon_test.go
+++ b/latlon_test.go
@@ -1,0 +1,48 @@
+package nvector_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/ezzatron/nvector-go"
+	"github.com/ezzatron/nvector-go/internal/rapidgen"
+	"github.com/ezzatron/nvector-go/internal/testapi"
+	"gonum.org/v1/gonum/mat"
+	"pgregory.net/rapid"
+)
+
+func Test_FromLatLon(t *testing.T) {
+	client, err := testapi.NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		client.Close()
+	})
+
+	ctx := context.Background()
+
+	t.Run("it matches the reference implementation", func(t *testing.T) {
+		rapid.Check(t, func(t *rapid.T) {
+			latitude := rapidgen.Latitude().Draw(t, "latitude")
+			longitude := rapidgen.Longitude().Draw(t, "longitude")
+			opts := rapidgen.Options().Draw(t, "opts")
+
+			want, err := client.FromLatLon(ctx, latitude, longitude, opts...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := FromLatLon(latitude, longitude, opts...)
+
+			if !mat.EqualApprox(got, want, 1e-14) {
+				t.Errorf(
+					"FromLatLon(%v, %v) = %v; want %v",
+					latitude,
+					longitude,
+					got,
+					want,
+				)
+			}
+		})
+	})
+}

--- a/options.go
+++ b/options.go
@@ -1,0 +1,17 @@
+package nvector
+
+import (
+	"gonum.org/v1/gonum/mat"
+
+	"github.com/ezzatron/nvector-go/internal/options"
+)
+
+// Option is a functional option for n-vector calculations.
+type Option = options.Option
+
+// WithCoordFrame sets the coordinate frame option.
+func WithCoordFrame(CoordFrame mat.Matrix) Option {
+	return func(o *options.Options) {
+		o.CoordFrame = CoordFrame
+	}
+}


### PR DESCRIPTION
This PR:

- Sets up functional options for n-vector operations.
- Implements a client for https://github.com/ezzatron/nvector-test-api (just the one function for now)
- Implements rapid generators for latitude, longitude, and 3d rotation matrices
- Implements the `FromLatLon` function to convert from geodetic latitude + longitude to n-vector within a given coordinate frame.

See https://github.com/FFI-no/n-vector/blob/82d749a67cc9f332f48c51aa969cdc277b4199f2/nvector/lat_long2n_E.m